### PR TITLE
fix(dashboardMaquinas): resolvido bug do nome técnico

### DIFF
--- a/fablab-cite/src/app/admin/machineDashboard/page.tsx
+++ b/fablab-cite/src/app/admin/machineDashboard/page.tsx
@@ -24,7 +24,7 @@ export default function Page() {
           {machines.map((machine: Machine) => (
             <Table.Row key={machine.id}>
               <Table.Cell>{machine.apelido}</Table.Cell>
-              <Table.Cell>{machine.nomeTecnico}</Table.Cell>
+              <Table.Cell>{machine.nome_tecnico}</Table.Cell>
               <Table.Cell>{machine.descricao}</Table.Cell>
               <Table.Cell>{machine.imagem}</Table.Cell>
               <Table.Cell>

--- a/fablab-cite/src/entities/machine.ts
+++ b/fablab-cite/src/entities/machine.ts
@@ -1,7 +1,7 @@
 export interface Machine{
     id: number;
     apelido: string;
-    nomeTecnico: string;
+    nome_tecnico: string;
     imagem: string;
     descricao: string;
 }

--- a/fablab-cite/src/services/Machines/machines.ts
+++ b/fablab-cite/src/services/Machines/machines.ts
@@ -5,7 +5,7 @@ const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 export const MachinesService = {
     async fetchMachines(): Promise<Machine[]> {
         try {
-            const response = await fetch(`${apiUrl}/maquinas`)
+            const response = await fetch(`${apiUrl}maquinas`)
 
             if (!response.ok) {
                 throw new Error("Failed to fetch machines")


### PR DESCRIPTION
Nome técnico não estava aparecendo no dashboard de máquinas, alterei o nome do atributo de 'nomeTecnico' para 'nome_tecnico' na entidade machine localizada na pasta 'entities'. A partir disso, o erro se resolveu.

Closes #10 #12 