### PR TITLE
fix(dashboardMaquinas): corrige erro na URL da requisição #16

### DIFF
--- a/fablab-cite/src/services/Machines/machines.ts
+++ b/fablab-cite/src/services/Machines/machines.ts
@@ -5,7 +5,7 @@ const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 export const MachinesService = {
     async fetchMachines(): Promise<Machine[]> {
         try {
-            const response = await fetch(`${apiUrl}maquinas`)
+            const response = await fetch(`${apiUrl}/maquinas`)
 
             if (!response.ok) {
                 throw new Error("Failed to fetch machines")


### PR DESCRIPTION
Corrige a falta de uma '/' na construção da URL da API no arquivo 'machines.ts' (linha 8), impedindo que as máquinas fossem listadas corretamente no Dashboard. Agora, a listagem de máquinas é exibida corretamente sem erro de requisição.

Closes #16 